### PR TITLE
CD: Remove use of env var

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
           deno-version: v1.x
 
       - name: Build site
-        run: deno task build
+        run: deno task build --location=https://tskarhed.github.io/scoresly/
       
       - name: Setup Pages
         uses: actions/configure-pages@v3

--- a/_config.ts
+++ b/_config.ts
@@ -6,7 +6,6 @@ const site = lume({
   server: {
     port: 8080,
   },
-  location: new URL(Deno.env.get("DEPLOY_URL")),
 });
 
 site.copy("scoresly.css");


### PR DESCRIPTION
Uses the --location cli option at build instead.